### PR TITLE
Adding .gitignore to avoid including dependency modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Dependency directories
+node_modules


### PR DESCRIPTION
This pull request is to address the issue of if you run `npm install npm start` during development it will add dependencies we would not want in the repo. They are listed below.
- node_modules/.bin/npm
- node_modules/npm/
- node_modules/start/

I've added a .gitignore file that handles this.
