### PR TITLE
Side by side view for larger devices

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,11 +17,11 @@
     <div class="container">
       <div class="page-header text-center m-t-1 m-b-3">
         <h1 class="display-4 text-xs-center">Song Length Estimator</h1>
-          <p class="lead text-xs-center">4/4 only</p>            
-          <p class="text-xs-center font-italic"><small>Built with <a href="https://facebook.github.io/react/">React</a></small></p>
+        <p class="lead text-xs-center">4/4 only</p>
+        <p class="text-xs-center font-italic"><small>Built with <a href="https://facebook.github.io/react/">React</a></small></p>
       </div>
-      <div id="formContainer"></div>
-      <div id="tableContainer"></div>
+      <div id="formContainer" class="col-xs-12 col-md-6"></div>
+      <div id="tableContainer" class="col-xs-12 col-md-6"></div>
     </div>
     <script type="text/babel" src="scripts/estimator.js"></script>
   </body>


### PR DESCRIPTION
Currently the 12-col looks great for mobile/smaller devices where you want to be able to see all the information from Estimator.

This pull request is to for medium to larger devices have the two main containers be side by side instead of vertically stacked so you can see all the information without having to scroll down as shown below.

<img width="960" alt="sidebyside" src="https://cloud.githubusercontent.com/assets/1641767/19253278/fcd24b74-8f17-11e6-83ae-384bac43851c.png">

Also addressed a minor spacing issue.
